### PR TITLE
Use the real app metadata and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>My Google AI Studio App</title>
+    <title>Data Storyteller Quest</title>
+    <meta
+      name="description"
+      content="A gamified data storytelling challenge for practicing stakeholder communication, chart choices, and narrative framing."
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="8" x2="56" y1="8" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#818cf8" />
+      <stop offset="1" stop-color="#ec4899" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#020617" />
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#bg)" />
+  <path
+    d="M19 42c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v4c0 1.1-.9 2-2 2h-3c-1.1 0-2-.9-2-2zm10-10c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v14c0 1.1-.9 2-2 2h-3c-1.1 0-2-.9-2-2zm10-8c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v22c0 1.1-.9 2-2 2h-3c-1.1 0-2-.9-2-2z"
+    fill="#fff"
+  />
+  <path d="M18 22c7.5-8.2 16.6-8 28 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-width="3" />
+</svg>


### PR DESCRIPTION
## Summary
- replace the placeholder browser title with the actual product name
- add a description meta tag that matches the app experience
- ship a lightweight SVG favicon so the app no longer 404s for browser icon requests

## Testing
- npm run lint
- npm run build
- verified in the browser that the page title is Data Storyteller Quest
- verified the console no longer reports a missing favicon request

Fixes #6